### PR TITLE
make it possible to specify parameters for the JVM that XJC runs in

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ replace with `Test` to configure that scope.
     <td></td>
   </tr>
   <tr>
+    <td>xjcJvmOpts</td><td>Seq[String]</td><td></td><td>Additional JVM command line, e.g. -Djavax.xml.accessExternalSchema=file to allow compilation of schemas consisting of multiple files</td>
+    <td></td>
+  </tr>
+  <tr>
     <td>sources in (Compile, xjc)</td><td>Seq[File]</td><td>${unmanagedResourceDirectories} ** "*.xsd"</td><td>Input XSD Files</td>
     <td>sources in (Compile, xjc) &lt;&lt;= sourceDirectory map (_ / "main" / "schema" ** "*.xsd" get)
 


### PR DESCRIPTION
Hey guys,

I'm trying to use sbt-xjc to compile a rather large schema consisting of multiple files. This won't work unless I pass the -Djavax.xml.accessExternalSchema=file flag to the JVM, so I added a way to do that. I hope this seems useful to you and I'd appreciate a timely release of a new version of the plugin that includes this change.

Cheers,
Matthias
