### PR TITLE
GH-28 Added javax.activation to default xjcLibts

### DIFF
--- a/src/main/scala/com/github/retronym/sbtxjc/SbtXjcPlugin.scala
+++ b/src/main/scala/com/github/retronym/sbtxjc/SbtXjcPlugin.scala
@@ -39,7 +39,8 @@ object SbtXjcPlugin extends AutoPlugin {
     xjcPlugins        := Seq(),
     xjcLibs           := Seq(
       "org.glassfish.jaxb" % "jaxb-xjc"  % "2.2.11",
-      "com.sun.xml.bind"   % "jaxb-impl" % "2.2.11"
+      "com.sun.xml.bind"   % "jaxb-impl" % "2.2.11",
+      "javax.activation" % "activation" % "1.1.1"
     ),
     libraryDependencies ++= xjcLibs.value.map(_ % XjcTool.name),
     libraryDependencies ++= xjcPlugins.value.map(_ % XjcPlugin.name)

--- a/src/main/scala/com/github/retronym/sbtxjc/SbtXjcPlugin.scala
+++ b/src/main/scala/com/github/retronym/sbtxjc/SbtXjcPlugin.scala
@@ -40,7 +40,7 @@ object SbtXjcPlugin extends AutoPlugin {
     xjcLibs           := Seq(
       "org.glassfish.jaxb" % "jaxb-xjc"  % "2.2.11",
       "com.sun.xml.bind"   % "jaxb-impl" % "2.2.11",
-      "javax.activation" % "activation" % "1.1.1"
+      "javax.activation"   % "activation" % "1.1.1"
     ),
     libraryDependencies ++= xjcLibs.value.map(_ % XjcTool.name),
     libraryDependencies ++= xjcPlugins.value.map(_ % XjcPlugin.name)


### PR DESCRIPTION
Solves GH-28

Works for both openjdk 11.0.7 and 1.8.0_252.